### PR TITLE
Updates for MPB 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-MathProgBase 0.3.8 0.4.0-
+MathProgBase 0.4.0 0.5.0-


### PR DESCRIPTION
Ref #22 and https://github.com/JuliaOpt/MathProgBase.jl/pull/91
Can't merge until CoinOptServices updates to support MPB 0.4 otherwise tests break.

@mlubin It's pretty simple, but the macro to generate the wrapper functions seems a bit hacky. Any ideas for a better way?

It passes tests locally after fixing the conflicts with CoinOptServices re. supporting MPB 0.4.