### PR TITLE
Use string array for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,7 @@ You can then model and solve your optimization problem as usual. See [JuMP's doc
 
 The ``AmplNLSolver()`` constructor requires as the first argument the name of the solver command needed to run the desired solver. For example, if the ``bonmin`` executable is on the system path, you can use this solver using ``AmplNLSolver("bonmin")``. If the solver is not on the path, the full path to the solver will need to be passed in. This solver executable must be an AMPL-compatible solver.
 
-The second (optional) argument to ``AmplNLSolver()`` is a ``Dict{String, Any}`` of solver options. These should be specified with the name of the option as the key, and the desired value as the value. For example, to set the NLP log level to 0 in Bonmin, you would run ``AmplNLSolver("bonmin", Dict("bonmin.nlp_log_level"=>0))``. For a list of options supported by your solver, check the solver's documentation, or run ``/path/to/solver -=`` at the command line e.g. run ``bonmin -=`` for a list of all Bonmin options.
-
-If you have [CoinOptServices.jl](https://github.com/JuliaOpt/CoinOptServices.jl) installed, you can easily use the Bonmin or Couenne solvers installed by this package:
-
-- Bonmin: ``BonminNLSolver(options)``
-- Couenne: ``CouenneNLSolver(options)``
-
-Similarly, if you have [Ipopt.jl](https://github.com/JuliaOpt/Ipopt.jl) installed, you can use Ipopt by using the solver `IpoptNLSolver(options)`.
+The second (optional) argument to ``AmplNLSolver()`` is a ``Vector{ASCIIString}`` of solver options. These options are appended to the solve command separated by spaces, and the required format depends on the solver that you are using. Generally, they will be of the form ``"key=value"``, where ``key`` is the name of the option to set and ``value`` is the desired value. For example, to set the NLP log level to 0 in Bonmin, you would run ``AmplNLSolver("bonmin", ["bonmin.nlp_log_level=0"])``. For a list of options supported by your solver, check the solver's documentation, or run ``/path/to/solver -=`` at the command line e.g. run ``bonmin -=`` for a list of all Bonmin options.
 
 In the `examples` folder you can see a range of problems solved using this package via JuMP.
 
@@ -53,3 +46,46 @@ These can be accessed as follows:
     @show get_solve_message(ampl_model)
     @show get_solve_exitcode(ampl_model)
 
+## Guides for specific solvers
+
+### Bonmin/Couenne/Ipopt
+
+If you have [CoinOptServices.jl](https://github.com/JuliaOpt/CoinOptServices.jl) installed, you can easily use the Bonmin or Couenne solvers installed by this package:
+
+- Bonmin: ``BonminNLSolver(options)``
+- Couenne: ``CouenneNLSolver(options)``
+
+Similarly, if you have [Ipopt.jl](https://github.com/JuliaOpt/Ipopt.jl) installed, you can use Ipopt by using the solver `IpoptNLSolver(options)`.
+
+Bonmin, Couenne and Ipopt all take options in the format ``"key=value"``, and the available options can be seen by running ``/path/to/bonmin -=`` and similarly for the other solvers. For example, the following will turn off the logging in Bonmin for both the NLP and Branch and Bound solvers:
+
+    BonminNLSolver(["bonmin.nlp_log_level=0"; "bonmin.bb_log_level=0"])
+
+Note that some of the options don't seem to take effect when specified using the command-line options (especially for Couenne), and instead you need to use an ``.opt`` file. The ``.opt`` file takes the name of the solver, e.g. ``bonmin.opt``, and each line of this file contains an option name and the desired value separated by a space. For instance, to set the absolute and relative tolerances in Couenne to 1 and 0.05 respectively, the ``couenne.opt`` file should be
+
+```
+allowable_gap 1
+allowable_fraction_gap 0.05
+```
+
+In order for the options to be loaded, this file must be located in the current working directory whenever the model is solved.
+
+A list of available options for the respective ``.opt`` files can be found here:
+
+- [Ipopt](http://www.coin-or.org/Ipopt/documentation/node39.html#app.options_ref)
+- [Bonmin](https://github.com/coin-or/Bonmin/blob/master/Bonmin/test/bonmin.opt) (plus Ipopt options)
+- [Couenne](https://github.com/coin-or/Couenne/blob/master/Couenne/src/couenne.opt) (plus Ipopt and Bonmin options)
+
+### SCIP
+
+To use SCIP with AmplNLWriter.jl, you must first compile the ``scipampl`` binary which is a version of SCIP with support for the AMPL .nl interface. To do this, you can follow the instructions [here](http://zverovich.net/2012/08/07/using-scip-with-ampl.html), which we have tested on OS X and Linux.
+
+After doing this, you can access SCIP through ``AmplNLSolver("/path/to/scipampl")``. Options can be specified for SCIP using a ``scip.set`` file, where each line is of the form ``key = value``. For example, the following `scip.set` file will set the verbosity level to 0:
+
+    display/verblevel = 0
+
+A list of valid options for the file can be found [here](http://plato.asu.edu/milp/scip.set).
+
+To use the ``scip.set`` file, you must pass the path to the ``scip.set`` file as the first (and only) option to the solver:
+
+    AmplNLSolver("/path/to/scipampl", ["/path/to/scip.set"])

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -34,20 +34,17 @@ function AmplNLSolver(solver_command::AbstractString,
     AmplNLSolver(solver_command, options, filename)
 end
 
-function BonminNLSolver(options::Vector{ASCIIString}=ASCIIString[];
-                        filename::AbstractString="")
+function BonminNLSolver(options=ASCIIString[]; filename::AbstractString="")
     osl || error("CoinOptServices not installed. Please run\n",
                  "Pkg.add(\"CoinOptServices\")")
     AmplNLSolver(CoinOptServices.bonmin, options; filename=filename)
 end
-function CouenneNLSolver(options::Vector{ASCIIString}=ASCIIString[];
-                         filename::AbstractString="")
+function CouenneNLSolver(options=ASCIIString[]; filename::AbstractString="")
     osl || error("CoinOptServices not installed. Please run\n",
                  "Pkg.add(\"CoinOptServices\")")
     AmplNLSolver(CoinOptServices.couenne, options; filename=filename)
 end
-function IpoptNLSolver(options::Vector{ASCIIString}=ASCIIString[];
-                       filename::AbstractString="")
+function IpoptNLSolver(options=ASCIIString[]; filename::AbstractString="")
     ipt || error("Ipopt not installed. Please run\nPkg.add(\"Ipopt\")")
     AmplNLSolver(Ipopt.amplexe, options; filename=filename)
 end
@@ -154,6 +151,7 @@ type AmplNLNonlinearModel <: AbstractNonlinearModel
 end
 
 include("nl_write.jl")
+include("deprecated.jl")
 
 NonlinearModel(s::AmplNLSolver) = AmplNLNonlinearModel(
     AmplNLMathProgModel(s.solver_command, s.options, s.filename)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,7 @@
+function AmplNLSolver(solver_command::AbstractString,
+                      options::Dict{ASCIIString,}=Dict{ASCIIString,}();
+                      filename::AbstractString="")
+  Base.warn_once("Specifying options with a Dict is deprecated. Use a Vector{ASCIIString} to specify options instead, e.g.,\n\tAmplNLSolver(\"/path/to/solver\", [\"option1=value1\";\"option2=value2\";...])")
+  AmplNLSolver(solver_command, ["$key=$value" for (key, value) in options],
+               filename=filename)
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -2,6 +2,7 @@ function AmplNLSolver(solver_command::AbstractString,
                       options::Dict{ASCIIString,}=Dict{ASCIIString,}();
                       filename::AbstractString="")
   Base.warn_once("Specifying options with a Dict is deprecated. Use a Vector{ASCIIString} to specify options instead, e.g.,\n\tAmplNLSolver(\"/path/to/solver\", [\"option1=value1\";\"option2=value2\";...])")
-  AmplNLSolver(solver_command, ["$key=$value" for (key, value) in options],
+  AmplNLSolver(solver_command,
+               ASCIIString["$key=$value" for (key, value) in options],
                filename=filename)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,15 @@ include("nl_write.jl")
 
 solver = JuMP.UnsetSolver()
 solvers = Any[]
-push!(solvers, BonminNLSolver(Dict("bonmin.nlp_log_level"=>0,
-                                           "bonmin.bb_log_level"=>0)))
-push!(solvers, CouenneNLSolver(Dict("bonmin.nlp_log_level"=>0,
-                                            "bonmin.bb_log_level"=>0)))
-push!(solvers, IpoptNLSolver(Dict("print_level"=>0)))
+push!(solvers, IpoptNLSolver(["print_level=0"]))
+push!(solvers, BonminNLSolver(["bonmin.nlp_log_level=0";
+                               "bonmin.bb_log_level=0"]))
+push!(solvers, CouenneNLSolver(["bonmin.nlp_log_level=0";
+                                "bonmin.bb_log_level=0"]))
+# Add tolerance option for couenne
+open("couenne.opt", "w") do f
+  write(f, "allowable_fraction_gap 0.0001")
+end
 
 examples_path = joinpath(dirname(dirname(@__FILE__)), "examples")
 for solver in solvers
@@ -34,7 +38,9 @@ for solver in solvers
     end
 end
 
-include(Pkg.dir("JuMP","test","solvers.jl")) # on JuMP 0.10, these assume Compat is loaded
+include(Pkg.dir("JuMP","test","solvers.jl"))
 include(Pkg.dir("JuMP","test","nonlinear.jl"))
+
+rm("couenne.opt")
 
 FactCheck.exitstatus()


### PR DESCRIPTION
Ref #26, this changes the options to use a vector of strings so that options that aren't `key=value` can be specified, in particular, the path to the `scip.set` options file for `scipampl`.

This also adds to the readme some instructions about how to use the options with the COIN-OR solvers and SCIP (as well as some info on setting SCIP up, ref JuliaOpt/JuMP.jl#588)