### PR TITLE
return NaN solution on solver error

### DIFF
--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -393,6 +393,7 @@ function optimize!(m::AmplNLMathProgModel)
         read_results(m)
     else
         m.status = :Error
+        m.solution = fill(NaN,m.nvar)
         m.solve_result = "failure"
         m.solve_result_num = 999
     end


### PR DESCRIPTION
I think this is preferable to returning a vector of length 0 for ``getsolutuion`` in the ``:Error`` case, which can cause JuMP to crash.