### PR TITLE
Revamp for Julia v0.6

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ env:
 # them after the tests have run
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("AmplNLWriter"); Pkg.add("Cbc"); Pkg.add("Ipopt"); Pkg.add("CoinOptServices"); Pkg.test("AmplNLWriter")'
+ - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("AmplNLWriter"); Pkg.add("Ipopt"); Pkg.test("AmplNLWriter")'
 before_cache:
-  - cp -R $HOME/.julia/*/Cbc/deps/usr $HOME
   - cp -R $HOME/.julia/*/Ipopt/deps/usr $HOME
-  - cp -R $HOME/.julia/*/CoinOptServices/deps/usr $HOME
+after_success:
+  # push coverage results to Codecov
+  - julia -e 'cd(Pkg.dir("AmplNLWriter")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
-  - nightly
+  - 0.6
 notifications:
   email: false
 sudo: false

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # AmplNLWriter.jl
 
-Linux, OSX: [![Build Status](https://travis-ci.org/JuliaOpt/AmplNLWriter.jl.svg?branch=master)](https://travis-ci.org/JuliaOpt/AmplNLWriter.jl)
+| **Build Status (Linux, OSX)** | **Build Status (Windows)** | **Coverage** |
+|:-----------------:|:--------------------:|:----------------:|
+| [![][build-img]][build-url] | [![Build Status][app-build-img]][app-build-url] | [![Codecov branch][codecov-img]][codecov-url]
 
-Windows: [![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaOpt/AmplNLWriter.jl?branch=master&svg=true)](https://ci.appveyor.com/project/jackdunnnz/amplnlwriter-jl/branch/master)
+[build-img]: https://travis-ci.org/JuliaOpt/AmplNLWriter.jl.svg?branch=master
+[build-url]: https://travis-ci.org/JuliaOpt/AmplNLWriter.jl
 
+[app-build-img]: https://ci.appveyor.com/api/projects/status/github/JuliaOpt/AmplNLWriter.jl?branch=master&svg=true
+[app-build-url]: https://ci.appveyor.com/project/jackdunnnz/amplnlwriter-jl/branch/master
+
+[codecov-img]: https://codecov.io/github/JuliaOpt/AmplNLWriter.jl/coverage.svg?branch=master
+[codecov-url]: https://codecov.io/github/JuliaOpt/AmplNLWriter.jl?branch=master
 
 This [Julia](https://github.com/JuliaLang/julia) package is an interface between [MathProgBase.jl](https://github.com/JuliaOpt/MathProgBase.jl) and [AMPL-enabled](http://www.ampl.com) [solvers](http://ampl.com/products/solvers/all-solvers-for-ampl/). It is similar in nature to [CoinOptServices.jl](https://github.com/tkelman/CoinOptServices.jl), but instead uses AMPL's low-level [.nl](https://en.wikipedia.org/wiki/Nl_%28format%29) file format.
 
@@ -26,7 +34,7 @@ AmplNLWriter.jl provides ``AmplNLSolver`` as a usable solver in JuMP. The follow
     julia> using JuMP, AmplNLWriter
     julia> m = Model(solver=AmplNLSolver("bonmin"))
 
-You can then model and solve your optimization problem as usual. See [JuMP's documentation](http://jump.readthedocs.org/en/latest/) for more details.
+You can then model and solve your optimization problem as usual. See [JuMP.jl](https://github.com/JuliaOpt/JuMP.jl/blob/master/README.md) for more details.
 
 The ``AmplNLSolver()`` constructor requires as the first argument the name of the solver command needed to run the desired solver. For example, if the ``bonmin`` executable is on the system path, you can use this solver using ``AmplNLSolver("bonmin")``. If the solver is not on the path, the full path to the solver will need to be passed in. This solver executable must be an AMPL-compatible solver.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ AmplNLWriter.jl provides ``AmplNLSolver`` as a usable solver in JuMP. The follow
     julia> using JuMP, AmplNLWriter
     julia> m = Model(solver=AmplNLSolver("bonmin"))
 
-You can then model and solve your optimization problem as usual. See [JuMP's documentation](http://jump.readthedocs.org/en/latest/) for more details. 
+You can then model and solve your optimization problem as usual. See [JuMP's documentation](http://jump.readthedocs.org/en/latest/) for more details.
 
 The ``AmplNLSolver()`` constructor requires as the first argument the name of the solver command needed to run the desired solver. For example, if the ``bonmin`` executable is on the system path, you can use this solver using ``AmplNLSolver("bonmin")``. If the solver is not on the path, the full path to the solver will need to be passed in. This solver executable must be an AMPL-compatible solver.
 
@@ -57,16 +57,19 @@ These can be accessed as follows:
 
 ### Bonmin/Couenne/Ipopt
 
+**NOTE: AmplNLWriter v0.4.0 introduced a breaking change by removing `BonminNLSolver`, `CouenneNLSolver`, and `IpoptNLSolver`. Users are now expected
+to pass the path of the solver executable to `AmplNLSolver`.**
+
 If you have [CoinOptServices.jl](https://github.com/JuliaOpt/CoinOptServices.jl) installed, you can easily use the Bonmin or Couenne solvers installed by this package:
 
-- Bonmin: ``BonminNLSolver(options)``
-- Couenne: ``CouenneNLSolver(options)``
+- Bonmin: ``AmplNLSolver(CoinOptServices.bonmin, options)``
+- Couenne: ``AmplNLSolver(CoinOptServices.couenne, options)``
 
-Similarly, if you have [Ipopt.jl](https://github.com/JuliaOpt/Ipopt.jl) installed, you can use Ipopt by using the solver `IpoptNLSolver(options)`.
+Similarly, if you have [Ipopt.jl](https://github.com/JuliaOpt/Ipopt.jl) installed, you can use Ipopt by using the solver `AmplNLSolver(Ipopt.amplexe, options)`.
 
 Bonmin, Couenne and Ipopt all take options in the format ``"key=value"``, and the available options can be seen by running ``/path/to/bonmin -=`` and similarly for the other solvers. For example, the following will turn off the logging in Bonmin for both the NLP and Branch and Bound solvers:
 
-    BonminNLSolver(["bonmin.nlp_log_level=0"; "bonmin.bb_log_level=0"])
+    AmplNLSolver(CoinOptServices.bonmin, ["bonmin.nlp_log_level=0"; "bonmin.bb_log_level=0"])
 
 Note that some of the options don't seem to take effect when specified using the command-line options (especially for Couenne), and instead you need to use an ``.opt`` file. The ``.opt`` file takes the name of the solver, e.g. ``bonmin.opt``, and each line of this file contains an option name and the desired value separated by a space. For instance, to set the absolute and relative tolerances in Couenne to 1 and 0.05 respectively, the ``couenne.opt`` file should be
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
-MathProgBase 0.5 0.7
+julia 0.6
+MathProgBase 0.5 0.8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
 
 branches:
   only:

--- a/examples/jump_const_obj.jl
+++ b/examples/jump_const_obj.jl
@@ -1,18 +1,18 @@
-using JuMP, FactCheck, AmplNLWriter
+using JuMP, Base.Test, AmplNLWriter
 
 # Example with no objective (#50)
 
 if !isdefined(:solver); solver = BonminNLSolver(); end
 
-m = Model(solver=solver)
-@variable(m, 0 <= yp <= 1, Int)
-@variable(m, 0 <= l <= 1000.0)
-@variable(m, 0 <= f <= 1000.0)
-@NLconstraint(m, .087 * l >= f ^ 2)
-@constraint(m, l <= yp * 1000.0)
-@objective(m, Min, 5)
+@testset "example: jump_no_obj" begin
+    m = Model(solver=solver)
+    @variable(m, 0 <= yp <= 1, Int)
+    @variable(m, 0 <= l <= 1000.0)
+    @variable(m, 0 <= f <= 1000.0)
+    @NLconstraint(m, .087 * l >= f ^ 2)
+    @constraint(m, l <= yp * 1000.0)
+    @objective(m, Min, 5)
 
-context("example: jump_no_obj") do
-    @fact solve(m) --> :Optimal
-    @fact getobjectivevalue(m) --> 5
+    @test solve(m) == :Optimal
+    @test getobjectivevalue(m) == 5
 end

--- a/examples/jump_const_obj.jl
+++ b/examples/jump_const_obj.jl
@@ -2,7 +2,7 @@ using JuMP, Base.Test, AmplNLWriter
 
 # Example with no objective (#50)
 
-if !isdefined(:solver); solver = BonminNLSolver(); end
+# solver = AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
 
 @testset "example: jump_no_obj" begin
     m = Model(solver=solver)

--- a/examples/jump_maxmin.jl
+++ b/examples/jump_maxmin.jl
@@ -1,4 +1,4 @@
-using JuMP, FactCheck, AmplNLWriter
+using JuMP, Base.Test, AmplNLWriter
 
 if !isdefined(:solver); solver = IpoptNLSolver(); end
 # Note min and max not implemented in Couenne
@@ -11,13 +11,13 @@ if !isdefined(:solver); solver = IpoptNLSolver(); end
  #  The optimal objective value is 0.25.
  #      x = 0.5
 ##
-context("example: maxmin") do
+@testset "example: maxmin" begin
     m = Model(solver=solver)
     @variable(m, -0.5 <= x <= 0.5, start = 0.25)
     @NLobjective(m, Max, min(x^2, 0.3, x))
-    @fact solve(m) --> :Optimal
-    @fact getobjectivevalue(m) --> roughly(0.25, 1e-2)
-    @fact getvalue(x) --> roughly(0.5, 1e-2)
+    @test solve(m) == :Optimal
+    @test isapprox(getobjectivevalue(m), 0.25, atol=1e-2)
+    @test isapprox(getvalue(x), 0.5, atol=1e-2)
 end
 
 ## Solve test problem with simple max functions
@@ -28,11 +28,11 @@ end
  #  The optimal objective value is 0.
  #      x = 0.
 ##
-context("example: minmax") do
+@testset "example: minmax" begin
     m = Model(solver=solver)
     @variable(m, -1 <= x <= 1, start=-1)
     @NLobjective(m, Min, max(x^2, x, -1))
-    @fact solve(m) --> :Optimal
-    @fact getobjectivevalue(m) --> roughly(0, 1e-2)
-    @fact getvalue(x) --> roughly(0, 1e-2)
+    @test solve(m) == :Optimal
+    @test isapprox(getobjectivevalue(m), 0, atol=1e-2)
+    @test isapprox(getvalue(x), 0, atol=1e-2)
 end

--- a/examples/jump_maxmin.jl
+++ b/examples/jump_maxmin.jl
@@ -1,6 +1,7 @@
 using JuMP, Base.Test, AmplNLWriter
 
-if !isdefined(:solver); solver = IpoptNLSolver(); end
+# solver = AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
+
 # Note min and max not implemented in Couenne
 
 ## Solve test problem with simple min functions

--- a/examples/jump_minlp.jl
+++ b/examples/jump_minlp.jl
@@ -1,4 +1,4 @@
-using JuMP, FactCheck, AmplNLWriter
+using JuMP, Base.Test, AmplNLWriter
 
 ## Solve test problem 1 (Synthesis of processing system) in
  #  M. Duran & I.E. Grossmann, "An outer approximation algorithm for
@@ -26,22 +26,26 @@ using JuMP, FactCheck, AmplNLWriter
 
 if !isdefined(:solver); solver = BonminNLSolver(); end
 
-m = Model(solver=solver)
-x_U = [2,2,1]
-@variable(m, x_U[i] >= x[i=1:3] >= 0)
-@variable(m, y[4:6], Bin)
+@testset "example: jump_minlp" begin
+    m = Model(solver=solver)
+    x_U = [2,2,1]
+    @variable(m, x_U[i] >= x[i=1:3] >= 0)
+    @variable(m, y[i=4:6], Bin)
 
-@NLobjective(m, Min, 10 + 10*x[1] - 7*x[3] + 5*y[4] + 6*y[5] + 8*y[6] - 18*log(x[2]+1) - 19.2*log(x[1]-x[2]+1))
-@NLconstraint(m, 0.8*log(x[2] + 1) + 0.96*log(x[1] - x[2] + 1) - 0.8*x[3] >= 0)
-@NLconstraint(m, log(x[2] + 1) + 1.2*log(x[1] - x[2] + 1) - x[3] - 2*y[6] >= -2)
-@NLconstraint(m, x[2] - x[1] <= 0)
-@NLconstraint(m, x[2] - 2*y[4] <= 0)
-@NLconstraint(m, x[1] - x[2] - 2*y[5] <= 0)
-@NLconstraint(m, y[4] + 2*y[5]*0.5 <= 1)
+    @NLobjective(m, Min, 10 + 10*x[1] - 7*x[3] + 5*y[4] + 6*y[5] + 8*y[6] - 18*log(x[2]+1) - 19.2*log(x[1]-x[2]+1))
+    @NLconstraint(m, 0.8*log(x[2] + 1) + 0.96*log(x[1] - x[2] + 1) - 0.8*x[3] >= 0)
+    @NLconstraint(m, log(x[2] + 1) + 1.2*log(x[1] - x[2] + 1) - x[3] - 2*y[6] >= -2)
+    @NLconstraint(m, x[2] - x[1] <= 0)
+    @NLconstraint(m, x[2] - 2*y[4] <= 0)
+    @NLconstraint(m, x[1] - x[2] - 2*y[5] <= 0)
+    @NLconstraint(m, y[4] + 2*y[5]*0.5 <= 1)
 
-context("example: jump_minlp") do
-    @fact solve(m) --> :Optimal
-    @fact getvalue(x)[:] --> roughly([1.30098, 0.0, 1.0], 1e-5)
-    @fact getvalue(y)[:] --> roughly([0.0, 1.0, 0.0], 1e-5)
-    @fact getobjectivevalue(m) --> roughly(6.00975, 1e-5)
+    @test solve(m) == :Optimal
+    # Ipopt solves the relaxation
+    @test isapprox(getvalue(x)[:], [1.14652, 0.546596, 1.0], atol=1e-5)
+    @test isapprox(getvalue(y)[:], [0.27330, 0.299959, 0.0], atol=1e-5)
+    @test isapprox(getobjectivevalue(m), 0.75928, atol=1e-5)
+    # @test isapprox(getvalue(x)[:], [1.30098, 0.0, 1.0], atol=1e-5)
+    # @test isapprox(getvalue(y)[:], [0.0, 1.0, 0.0], atol=1e-5)
+    # @test isapprox(getobjectivevalue(m), 6.00975, atol=1e-5)
 end

--- a/examples/jump_minlp.jl
+++ b/examples/jump_minlp.jl
@@ -24,7 +24,8 @@ using JuMP, Base.Test, AmplNLWriter
  #  The solution is (1.30098, 0, 1, 0, 1, 0).
  ##
 
-if !isdefined(:solver); solver = BonminNLSolver(); end
+ # solver = AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
+
 
 @testset "example: jump_minlp" begin
     m = Model(solver=solver)
@@ -41,11 +42,15 @@ if !isdefined(:solver); solver = BonminNLSolver(); end
     @NLconstraint(m, y[4] + 2*y[5]*0.5 <= 1)
 
     @test solve(m) == :Optimal
-    # Ipopt solves the relaxation
-    @test isapprox(getvalue(x)[:], [1.14652, 0.546596, 1.0], atol=1e-5)
-    @test isapprox(getvalue(y)[:], [0.27330, 0.299959, 0.0], atol=1e-5)
-    @test isapprox(getobjectivevalue(m), 0.75928, atol=1e-5)
-    # @test isapprox(getvalue(x)[:], [1.30098, 0.0, 1.0], atol=1e-5)
-    # @test isapprox(getvalue(y)[:], [0.0, 1.0, 0.0], atol=1e-5)
-    # @test isapprox(getobjectivevalue(m), 6.00975, atol=1e-5)
+
+    if getsolvername(solver) == "ipopt"
+        # Ipopt solves the relaxation
+        @test isapprox(getvalue(x)[:], [1.14652, 0.546596, 1.0], atol=1e-5)
+        @test isapprox(getvalue(y)[:], [0.27330, 0.299959, 0.0], atol=1e-5)
+        @test isapprox(getobjectivevalue(m), 0.75928, atol=1e-5)
+    else
+        @test isapprox(getvalue(x)[:], [1.30098, 0.0, 1.0], atol=1e-5)
+        @test isapprox(getvalue(y)[:], [0.0, 1.0, 0.0], atol=1e-5)
+        @test isapprox(getobjectivevalue(m), 6.00975, atol=1e-5)
+    end
 end

--- a/examples/jump_nlexpr.jl
+++ b/examples/jump_nlexpr.jl
@@ -2,7 +2,8 @@ using JuMP, Base.Test, AmplNLWriter
 
 # Example testing basic use of NLExpr with AmplNLWriter.jl
 
-if !isdefined(:solver); solver = IpoptNLSolver(); end
+# solver = AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
+
 
 @testset "example: jump_nlexpr" begin
     m = Model(solver=solver)

--- a/examples/jump_nlexpr.jl
+++ b/examples/jump_nlexpr.jl
@@ -1,32 +1,31 @@
-using JuMP, FactCheck, AmplNLWriter
+using JuMP, Base.Test, AmplNLWriter
 
 # Example testing basic use of NLExpr with AmplNLWriter.jl
 
 if !isdefined(:solver); solver = IpoptNLSolver(); end
 
-m = Model(solver=solver)
+@testset "example: jump_nlexpr" begin
+    m = Model(solver=solver)
 
-n = 30
-l = -ones(n); l[1] = 0
-u = ones(n)
-@variable(m, l[i] <= x[i=1:n] <= u[i])
-@NLexpression(m, f1, x[1])
-@NLexpression(m, g, 1 + 9 * sum{x[j] ^ 2, j = 2:n} / (n - 1))
-@NLexpression(m, h, 1 - (f1 / g) ^ 2)
-@NLexpression(m, f2, g * h)
+    n = 30
+    l = -ones(n); l[1] = 0
+    u = ones(n)
+    @variable(m, l[i] <= x[i=1:n] <= u[i])
+    @NLexpression(m, f1, x[1])
+    @NLexpression(m, g, 1 + 9 * sum(x[j] ^ 2 for j = 2:n) / (n - 1))
+    @NLexpression(m, h, 1 - (f1 / g) ^ 2)
+    @NLexpression(m, f2, g * h)
 
-setvalue(x[1], 1)
-setvalue(x[2:n], zeros(n - 1))
-@NLobjective(m, :Min, f2)
+    setvalue(x[1], 1)
+    setvalue(x[2:n], zeros(n - 1))
+    @NLobjective(m, :Min, f2)
 
-context("example: jump_nlexpr") do
-    @fact solve(m) --> :Optimal
-    @fact getvalue(x[1]) --> roughly(1.0, 1e-5)
-    @fact getvalue(x[2:end]) --> roughly(zeros(n - 1), 1e-5)
-    @fact getvalue(f1) --> roughly(1.0, 1e-5)
-    @fact getvalue(f2) --> roughly(0.0, 1e-5)
-    @fact getvalue(g) --> roughly(1.0, 1e-5)
-    @fact getvalue(h) --> roughly(0.0, 1e-5)
-    @fact getobjectivevalue(m) --> roughly(0.0, 1e-5)
+    @test solve(m) == :Optimal
+    @test isapprox(getvalue(x[1]), 1.0, atol=1e-5)
+    @test isapprox(getvalue(x[2:end]), zeros(n - 1), atol=1e-5)
+    @test isapprox(getvalue(f1), 1.0, atol=1e-5)
+    @test isapprox(getvalue(f2), 0.0, atol=1e-5)
+    @test isapprox(getvalue(g), 1.0, atol=1e-5)
+    @test isapprox(getvalue(h), 0.0, atol=1e-5)
+    @test isapprox(getobjectivevalue(m), 0.0, atol=1e-5)
 end
-

--- a/examples/jump_nltrig.jl
+++ b/examples/jump_nltrig.jl
@@ -1,4 +1,4 @@
-using JuMP, FactCheck, AmplNLWriter
+using JuMP, Base.Test, AmplNLWriter
 
 ## Solve test problem with sind and cosd functions
  #
@@ -8,26 +8,23 @@ using JuMP, FactCheck, AmplNLWriter
  #  The optimal objective value is 0
  ##
 
-# Allow resolving the model from multiple starts after NLP changes in JuMP 0.12
-EnableNLPResolve()
-
 if !isdefined(:solver); solver = CouenneNLSolver(); end
 
-m = Model(solver=solver)
-@variable(m, x[1:2])
+@testset "example: jump_nltrig" begin
+    m = Model(solver=solver)
+    @variable(m, x[1:2])
 
-@NLobjective(m, Min, (7 - (3*cosd(x[1]) + 5*cosd(x[2])))^2 + (0 - (3*sind(x[1]) + 5*sind(x[2])))^2)
+    @NLobjective(m, Min, (7 - (3*cosd(x[1]) + 5*cosd(x[2])))^2 + (0 - (3*sind(x[1]) + 5*sind(x[2])))^2)
 
-context("example: jump_nltrig") do
     setvalue(x[1], 30)
     setvalue(x[2], -50)
-    @fact solve(m) --> :Optimal
-    @fact getvalue(x)[:] --> roughly([38.21321, -21.78678], 1e-5)
-    @fact getobjectivevalue(m) --> roughly(0.0, 1e-5)
+    @test solve(m) == :Optimal
+    @test isapprox(getvalue(x)[:], [38.21321, -21.78678], atol=1e-5)
+    @test isapprox(getobjectivevalue(m), 0.0, atol=1e-5)
     # Now try from the other side
     setvalue(x[1], -30)
     setvalue(x[2], 50)
-    @fact solve(m) --> :Optimal
-    @fact getvalue(x)[:] --> roughly([-38.21321, 21.78678], 1e-5)
-    @fact getobjectivevalue(m) --> roughly(0.0, 1e-5)
+    @test solve(m) == :Optimal
+    @test isapprox(getvalue(x)[:], [-38.21321, 21.78678], atol=1e-5)
+    @test isapprox(getobjectivevalue(m), 0.0, atol=1e-5)
 end

--- a/examples/jump_nltrig.jl
+++ b/examples/jump_nltrig.jl
@@ -8,7 +8,7 @@ using JuMP, Base.Test, AmplNLWriter
  #  The optimal objective value is 0
  ##
 
-if !isdefined(:solver); solver = CouenneNLSolver(); end
+# solver = AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
 
 @testset "example: jump_nltrig" begin
     m = Model(solver=solver)

--- a/examples/jump_no_obj.jl
+++ b/examples/jump_no_obj.jl
@@ -1,17 +1,17 @@
-using JuMP, FactCheck, AmplNLWriter
+using JuMP, Base.Test, AmplNLWriter
 
 # Example with no objective (#50)
 
 if !isdefined(:solver); solver = BonminNLSolver(); end
 
-m = Model(solver=solver)
-@variable(m, 0 <= yp <= 1, Int)
-@variable(m, 0 <= l <= 1000.0)
-@variable(m, 0 <= f <= 1000.0)
-@NLconstraint(m, .087 * l >= f ^ 2)
-@constraint(m, l <= yp * 1000.0)
+@testset "example: jump_no_obj" begin
+    m = Model(solver=solver)
+    @variable(m, 0 <= yp <= 1, Int)
+    @variable(m, 0 <= l <= 1000.0)
+    @variable(m, 0 <= f <= 1000.0)
+    @NLconstraint(m, .087 * l >= f ^ 2)
+    @constraint(m, l <= yp * 1000.0)
 
-context("example: jump_no_obj") do
-    @fact solve(m) --> :Optimal
-    @fact getobjectivevalue(m) --> 0
+    @test solve(m) == :Optimal
+    @test getobjectivevalue(m) == 0
 end

--- a/examples/jump_no_obj.jl
+++ b/examples/jump_no_obj.jl
@@ -2,7 +2,7 @@ using JuMP, Base.Test, AmplNLWriter
 
 # Example with no objective (#50)
 
-if !isdefined(:solver); solver = BonminNLSolver(); end
+# solver = AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
 
 @testset "example: jump_no_obj" begin
     m = Model(solver=solver)

--- a/examples/jump_nonlinearbinary.jl
+++ b/examples/jump_nonlinearbinary.jl
@@ -8,7 +8,7 @@ using JuMP, Base.Test, AmplNLWriter
  #  The solution is (0, 0).
  ##
 
-if !isdefined(:solver); solver = BonminNLSolver(); end
+# solver = AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
 
 @testset "example: jump_nonlinearbinary" begin
     m = Model(solver=solver)
@@ -22,9 +22,13 @@ if !isdefined(:solver); solver = BonminNLSolver(); end
     @NLobjective(m, Min, 100*(x[2] - (0.5 + x[1])^2)^2 + (1 - x[1])^2)
 
     @test solve(m) == :Optimal
-    # Ipopt solves the relaxation
-    @test isapprox(getvalue(x), [0.501245, 1.0], atol=1e-6)
-    @test isapprox(getobjectivevalue(m), 0.249377, atol=1e-6)
-    # @test getvalue(x)[:] == [0.0, 0.0]
-    # @test getobjectivevalue(m) == 7.25
+
+    if getsolvername(solver) == "ipopt"
+        # Ipopt solves the relaxation
+        @test isapprox(getvalue(x), [0.501245, 1.0], atol=1e-6)
+        @test isapprox(getobjectivevalue(m), 0.249377, atol=1e-6)
+    else
+        @test getvalue(x)[:] == [0.0, 0.0]
+        @test getobjectivevalue(m) == 7.25
+    end
 end

--- a/examples/jump_nonlinearbinary.jl
+++ b/examples/jump_nonlinearbinary.jl
@@ -1,4 +1,4 @@
-using JuMP, FactCheck, AmplNLWriter
+using JuMP, Base.Test, AmplNLWriter
 
 ## Solve test problem with non-linear binary variables
  #
@@ -10,18 +10,21 @@ using JuMP, FactCheck, AmplNLWriter
 
 if !isdefined(:solver); solver = BonminNLSolver(); end
 
-m = Model(solver=solver)
-@variable(m, x[1:2], Bin)
+@testset "example: jump_nonlinearbinary" begin
+    m = Model(solver=solver)
+    @variable(m, x[1:2], Bin)
 
-# Set some non-binary bounds on x1 and x2. These should be ignored.
-# The optimal solution if x is Int is (1, 2) which is allowed by these bounds
-setupperbound(x[1], 2)
-setupperbound(x[2], 2)
+    # Set some non-binary bounds on x1 and x2. These should be ignored.
+    # The optimal solution if x is Int is (1, 2) which is allowed by these bounds
+    setupperbound(x[1], 2)
+    setupperbound(x[2], 2)
 
-@NLobjective(m, Min, 100*(x[2] - (0.5 + x[1])^2)^2 + (1 - x[1])^2)
+    @NLobjective(m, Min, 100*(x[2] - (0.5 + x[1])^2)^2 + (1 - x[1])^2)
 
-context("example: jump_nonlinearbinary") do
-    @fact solve(m) --> :Optimal
-    @fact getvalue(x)[:] --> [0.0, 0.0]
-    @fact getobjectivevalue(m) --> 7.25
+    @test solve(m) == :Optimal
+    # Ipopt solves the relaxation
+    @test isapprox(getvalue(x), [0.501245, 1.0], atol=1e-6)
+    @test isapprox(getobjectivevalue(m), 0.249377, atol=1e-6)
+    # @test getvalue(x)[:] == [0.0, 0.0]
+    # @test getobjectivevalue(m) == 7.25
 end

--- a/examples/jump_pruning.jl
+++ b/examples/jump_pruning.jl
@@ -16,7 +16,8 @@ using JuMP, Base.Test, AmplNLWriter
  #  The optimal objective value is 400, solutions can vary.
  ##
 
-if !isdefined(:solver); solver = IpoptNLSolver(); end
+# solver = AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
+
 @testset "example: jump_pruning" begin
     m = Model(solver=solver)
 

--- a/examples/jump_pruning.jl
+++ b/examples/jump_pruning.jl
@@ -1,4 +1,4 @@
-using JuMP, FactCheck, AmplNLWriter
+using JuMP, Base.Test, AmplNLWriter
 
 ## Solve test problem with lots of expressions to prune
  #
@@ -17,22 +17,22 @@ using JuMP, FactCheck, AmplNLWriter
  ##
 
 if !isdefined(:solver); solver = IpoptNLSolver(); end
-m = Model(solver=solver)
+@testset "example: jump_pruning" begin
+    m = Model(solver=solver)
 
-@variable(m, x[1:2] >= 0)
+    @variable(m, x[1:2] >= 0)
 
-@NLobjective(m, Max, x[1]^2 * x[2]^2)
-@NLconstraint(m, x[1] * x[2] <= 20)
-@NLconstraint(m, x[1] + x[2] <= 40)
-@NLconstraint(m, x[1] * x[2] + x[1] + x[2] <= 60)
-@NLconstraint(m, x[1] + x[1] * x[2] + x[2] <= 60)
-@NLconstraint(m, x[1] * x[2] + x[1] + x[2] <= 60)
-@NLconstraint(m, x[1] * x[2] - x[1] - x[2] <= 0)
-@NLconstraint(m, x[2] - x[1] * x[2] + x[1] <= 60)
-@NLconstraint(m, x[2] - x[1] + x[1] * x[2] <= 0)
-@NLconstraint(m, 0 <= 1.0)
+    @NLobjective(m, Max, x[1]^2 * x[2]^2)
+    @NLconstraint(m, x[1] * x[2] <= 20)
+    @NLconstraint(m, x[1] + x[2] <= 40)
+    @NLconstraint(m, x[1] * x[2] + x[1] + x[2] <= 60)
+    @NLconstraint(m, x[1] + x[1] * x[2] + x[2] <= 60)
+    @NLconstraint(m, x[1] * x[2] + x[1] + x[2] <= 60)
+    @NLconstraint(m, x[1] * x[2] - x[1] - x[2] <= 0)
+    @NLconstraint(m, x[2] - x[1] * x[2] + x[1] <= 60)
+    @NLconstraint(m, x[2] - x[1] + x[1] * x[2] <= 0)
+    @NLconstraint(m, 0 <= 1.0)
 
-context("example: jump_pruning") do
-    @fact solve(m) --> :Optimal
-    @fact getobjectivevalue(m) --> roughly(400, 1e-2)
+    @test solve(m) == :Optimal
+    @test isapprox(getobjectivevalue(m), 400, atol=1e-2)
 end

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -564,6 +564,11 @@ function add_to_index_maps!(forward_map::Dict{Int, Int},
 end
 
 function read_results(m::AmplNLMathProgModel)
+    if !isfile(m.solfile)
+        error("""Unable to open the solution file. The most likely cause of this
+        is the solver executable failing unexpectedly. Unfortunately we don't
+        have any other information about the solution or what went wrong.""")
+    end
     open(m.solfile, "r")do io
         read_results(io, m)
     end
@@ -631,7 +636,12 @@ function read_results(resultio, m::AmplNLMathProgModel)
 end
 
 function read_sol(m::AmplNLMathProgModel)
-    open(m.solfile, "r")do io
+    if !isfile(m.solfile)
+        error("""Unable to open the solution file. The most likely cause of this
+        is the solver executable failing unexpectedly. Unfortunately we don't
+        have any other information about the solution or what went wrong.""")
+    end
+    open(m.solfile, "r") do io
         readsol(io, m)
     end
 end

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -13,7 +13,7 @@ include("nl_linearity.jl")
 include("nl_params.jl")
 include("nl_convert.jl")
 
-export AmplNLSolver,
+export AmplNLSolver, BonminNLSolver, CouenneNLSolver, IpoptNLSolver,
        getsolvername, getsolveresult, getsolveresultnum, getsolvemessage,
        getsolveexitcode
 
@@ -30,49 +30,46 @@ function AmplNLSolver(solver_command::String,
 end
 
 function BonminNLSolver(options=String[]; filename::String="")
-    error("""
-        BonminNLSolver is no longer available by default through AmplNLWriter.
+    error("""BonminNLSolver is no longer available by default through AmplNLWriter.
 
-        You should install CoinOptServices via
+    You should install CoinOptServices via
 
-            Pkg.add("CoinOptServices")
+        Pkg.add("CoinOptServices")
 
-        and then replace BonminNLSolver(options=String[]; filename::String="")
-        with
+    and then replace BonminNLSolver(options=String[]; filename::String="")
+    with
 
-            AmplNLWriter(CoinOptServices.bonmin, options; filename=filename)
+        AmplNLSolver(CoinOptServices.bonmin, options; filename=filename)
 
     """)
 end
 
 function CouenneNLSolver(options=String[]; filename::String="")
-    error("""
-        CouenneNLSolver is no longer available by default through AmplNLWriter.
+    error("""CouenneNLSolver is no longer available by default through AmplNLWriter.
 
-        You should install CoinOptServices via
+    You should install CoinOptServices via
 
-            Pkg.add("CoinOptServices")
+        Pkg.add("CoinOptServices")
 
-        and then replace CouenneNLSolver(options=String[]; filename::String="")
-        with
+    and then replace CouenneNLSolver(options=String[]; filename::String="")
+    with
 
-            AmplNLWriter(CoinOptServices.couenne, options; filename=filename)
+        AmplNLSolver(CoinOptServices.couenne, options; filename=filename)
 
     """)
 end
 
 function IpoptNLSolver(options=String[]; filename::String="")
-    error("""
-        CouenneNLSolver is no longer available by default through AmplNLWriter.
+    error("""IpoptNLSolver is no longer available by default through AmplNLWriter.
 
-        You should install Ipopt via
+    You should install Ipopt via
 
-            Pkg.add("Ipopt")
+        Pkg.add("Ipopt")
 
-        and then replace IpoptNLSolver(options=String[]; filename::String="")
-        with
+    and then replace IpoptNLSolver(options=String[]; filename::String="")
+    with
 
-            AmplNLWriter(Ipopt.amplexe, options; filename=filename)
+        AmplNLSolver(Ipopt.amplexe, options; filename=filename)
 
     """)
 end

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -531,7 +531,7 @@ function add_to_index_maps!(forward_map::Dict{Int, Int},
 end
 
 function read_results(m::AmplNLMathProgModel)
-    open(m.solfile, "r") do io
+    open(m.solfile, "r")do io
         read_results(io, m)
     end
 end
@@ -598,7 +598,7 @@ function read_results(resultio, m::AmplNLMathProgModel)
 end
 
 function read_sol(m::AmplNLMathProgModel)
-    open(m.solfile, "r") do io
+    open(m.solfile, "r")do io
         readsol(io, m)
     end
 end
@@ -714,7 +714,7 @@ function substitute_vars!(c::Expr, x::Array{Float64})
                 c.args[1] = :+
             end
         end
-        map!(arg -> substitute_vars!(arg, x), c.args)
+        map!(arg -> substitute_vars!(arg, x), c.args, c.args)
     end
     c
 end

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -41,6 +41,9 @@ function BonminNLSolver(options=String[]; filename::String="")
 
         AmplNLSolver(CoinOptServices.bonmin, options; filename=filename)
 
+    alternatively, you can call
+
+        AmplNLSolver("path/to/bonmin", options; filename=filename)
     """)
 end
 
@@ -56,6 +59,9 @@ function CouenneNLSolver(options=String[]; filename::String="")
 
         AmplNLSolver(CoinOptServices.couenne, options; filename=filename)
 
+    alternatively, you can call
+
+        AmplNLSolver("path/to/couenne", options; filename=filename)
     """)
 end
 
@@ -71,6 +77,9 @@ function IpoptNLSolver(options=String[]; filename::String="")
 
         AmplNLSolver(Ipopt.amplexe, options; filename=filename)
 
+    alternatively, you can call
+
+        AmplNLSolver("path/to/ipopt", options; filename=filename)
     """)
 end
 

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -13,7 +13,7 @@ include("nl_linearity.jl")
 include("nl_params.jl")
 include("nl_convert.jl")
 
-export AmplNLSolver, BonminNLSolver, CouenneNLSolver, IpoptNLSolver,
+export AmplNLSolver,
        getsolvername, getsolveresult, getsolveresultnum, getsolvemessage,
        getsolveexitcode
 
@@ -23,12 +23,6 @@ immutable AmplNLSolver <: AbstractMathProgSolver
     filename::String
 end
 
-osl = isdir(Pkg.dir("CoinOptServices"))
-ipt = isdir(Pkg.dir("Ipopt"))
-
-if osl; import CoinOptServices; end
-if ipt; import Ipopt; end
-
 function AmplNLSolver(solver_command::String,
                       options::Vector{String}=String[];
                       filename::String="")
@@ -36,18 +30,51 @@ function AmplNLSolver(solver_command::String,
 end
 
 function BonminNLSolver(options=String[]; filename::String="")
-    osl || error("CoinOptServices not installed. Please run\n",
-                 "Pkg.add(\"CoinOptServices\")")
-    AmplNLSolver(CoinOptServices.bonmin, options; filename=filename)
+    error("""
+        BonminNLSolver is no longer available by default through AmplNLWriter.
+
+        You should install CoinOptServices via
+
+            Pkg.add("CoinOptServices")
+
+        and then replace BonminNLSolver(options=String[]; filename::String="")
+        with
+
+            AmplNLWriter(CoinOptServices.bonmin, options; filename=filename)
+
+    """)
 end
+
 function CouenneNLSolver(options=String[]; filename::String="")
-    osl || error("CoinOptServices not installed. Please run\n",
-                 "Pkg.add(\"CoinOptServices\")")
-    AmplNLSolver(CoinOptServices.couenne, options; filename=filename)
+    error("""
+        CouenneNLSolver is no longer available by default through AmplNLWriter.
+
+        You should install CoinOptServices via
+
+            Pkg.add("CoinOptServices")
+
+        and then replace CouenneNLSolver(options=String[]; filename::String="")
+        with
+
+            AmplNLWriter(CoinOptServices.couenne, options; filename=filename)
+
+    """)
 end
+
 function IpoptNLSolver(options=String[]; filename::String="")
-    ipt || error("Ipopt not installed. Please run\nPkg.add(\"Ipopt\")")
-    AmplNLSolver(Ipopt.amplexe, options; filename=filename)
+    error("""
+        CouenneNLSolver is no longer available by default through AmplNLWriter.
+
+        You should install Ipopt via
+
+            Pkg.add("Ipopt")
+
+        and then replace IpoptNLSolver(options=String[]; filename::String="")
+        with
+
+            AmplNLWriter(Ipopt.amplexe, options; filename=filename)
+
+    """)
 end
 
 getsolvername(s::AmplNLSolver) = basename(s.solver_command)

--- a/src/nl_convert.jl
+++ b/src/nl_convert.jl
@@ -3,7 +3,7 @@ convert_formula(c) = c
 convert_formula(c::LinearityExpr) = convert_formula(c.c)
 
 function convert_formula(c::Expr)
-    map!(convert_formula, c.args)
+    map!(convert_formula, c.args, c.args)
 
     if c.head == :comparison
         n = length(c.args)

--- a/src/nl_linearity.jl
+++ b/src/nl_linearity.jl
@@ -114,7 +114,7 @@ end
 get_expr(c) = c
 get_expr(c::LinearityExpr) = get_expr(c.c)
 function get_expr(c::Expr)
-    map!(get_expr, c.args)
+    map!(get_expr, c.args, c.args)
     return c
 end
 
@@ -123,7 +123,7 @@ function pull_up_constants(c::LinearityExpr)
     if c.linearity == :const
         c.c = eval(c)
     elseif isa(c.c, Expr)
-        map!(pull_up_constants, c.c.args)
+        map!(pull_up_constants, c.c.args, c.c.args)
     end
     return c
 end
@@ -144,11 +144,11 @@ function prune_linear_terms!(c::LinearityExpr, lin_constr::Dict{Int, Float64},
                     pruned[i - 1], expr.args[i], constant = prune_linear_terms!(
                         expr.args[i], lin_constr, constant, negative_tree)
                 end
-                if sum(!pruned) > 1
-                    inds = vcat([1], collect(2:n)[!pruned])
+                if sum(.!pruned) > 1
+                    inds = vcat([1], collect(2:n)[.!pruned])
                     c.c.args = expr.args[inds]
                 else
-                    c = expr.args[findfirst(!pruned) + 1]
+                    c = expr.args[findfirst(.!pruned) + 1]
                 end
             elseif expr.args[1] == :-
                 if length(expr.args) == 3
@@ -215,7 +215,7 @@ negate(c::LinearityExpr) = multiply(c::LinearityExpr, -1)
 function multiply(c::LinearityExpr, a::Real)
     if isa(c.c, Expr) && c.c.head == :call
         @assert c.c.args[1] == :+
-        map!(arg -> multiply(arg, a), c.c.args[2:end])
+        map!(arg -> multiply(arg, a), c.c.args[2:end], c.c.args[2:end])
     elseif c.linearity == :const
         c.c *= a
     else

--- a/src/nl_write.jl
+++ b/src/nl_write.jl
@@ -64,8 +64,9 @@ function write_nl_header(f, m::AmplNLMathProgModel)
     binary = m.vartypes .== :Bin
     integer = m.vartypes .== :Int
     discrete = binary + integer .> 0
-    nbv = sum(binary + !nonlinear .> 1)
-    niv = sum(integer + !nonlinear .> 1)
+    # Julia 0.6 syntax
+    nbv = sum(binary + .!nonlinear .> 1)
+    niv = sum(integer + .!nonlinear .> 1)
     nlvbi = sum(nonlinear_both + discrete .> 1)
     nlvci = sum(nonlinear_con - nonlinear_obj + discrete .> 1)
     nlvoi = sum(nonlinear_obj - nonlinear_con + discrete .> 1)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,3 @@
-FactCheck
 JuMP 0.13
-CoinOptServices 0.0.5
 Ipopt 0.1.15
 Compat

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,2 @@
 JuMP 0.13
 Ipopt 0.1.15
-Compat

--- a/test/nl_convert.jl
+++ b/test/nl_convert.jl
@@ -1,58 +1,56 @@
-using FactCheck
 import AmplNLWriter
 
-facts("[nl_convert] check special conversion cases") do
+@testset "[nl_convert] check special conversion cases" begin
     special_cases = [:cbrt, :abs2, :inv, :log2, :log1p, :exp2, :expm1, :sec,
                      :csc, :cot, :sind, :cosd, :tand, :asind, :acosd, :atand,
                      :secd, :cscd, :cotd, :sech, :csch, :coth, :asech, :acsch]
     for func in special_cases
         x = rand()
         expr = Expr(:call, func, x)
-        @fact (eval(AmplNLWriter.convert_formula(expr)) -->
-               roughly(eval(expr), 1e-6))
+        @test isapprox(eval(AmplNLWriter.convert_formula(expr)), eval(expr), atol=1e-6)
     end
     # These functions need input >1
     for func in [:acoth, :asec, :acsc, :acot, :asecd, :acscd, :acotd]
         x = rand() + 1
         expr = Expr(:call, func, x)
-        @fact (eval(AmplNLWriter.convert_formula(expr)) -->
-               roughly(eval(expr), 1e-6))
+        @test isapprox(eval(AmplNLWriter.convert_formula(expr)),
+               eval(expr), atol=1e-6)
     end
 end
 
-facts("[nl_convert] check numeric values") do
+@testset "[nl_convert] check numeric values" begin
     x = rand()
-    @fact AmplNLWriter.convert_formula(:($x)) --> :($x)
+    @test AmplNLWriter.convert_formula(:($x)) == :($x)
     x = -rand()
-    @fact AmplNLWriter.convert_formula(:($x)) --> :($x)
+    @test AmplNLWriter.convert_formula(:($x)) == :($x)
 end
 
-facts("[nl_convert] check unary, binary and n-ary plus") do
+@testset "[nl_convert] check unary, binary and n-ary plus" begin
     expr = :(+(1))
-    @fact AmplNLWriter.convert_formula(expr) --> :(1)
+    @test AmplNLWriter.convert_formula(expr) == :(1)
     expr = :(1 + 2)
-    @fact AmplNLWriter.convert_formula(expr) --> :(1 + 2)
+    @test AmplNLWriter.convert_formula(expr) == :(1 + 2)
     expr = :(1 + 2 + 3)
-    @fact AmplNLWriter.convert_formula(expr) --> :(sum(1, 2, 3))
+    @test AmplNLWriter.convert_formula(expr) == :(sum(1, 2, 3))
 end
 
-facts("[nl_convert] check unary, binary and n-ary minus") do
+@testset "[nl_convert] check unary, binary and n-ary minus" begin
     expr = :(- x)
-    @fact AmplNLWriter.convert_formula(expr) --> :(neg(x))
+    @test AmplNLWriter.convert_formula(expr) == :(neg(x))
     expr = :(x - y)
-    @fact AmplNLWriter.convert_formula(expr) --> :(x - y)
+    @test AmplNLWriter.convert_formula(expr) == :(x - y)
     expr = :(x - y - z)
-    @fact AmplNLWriter.convert_formula(expr) --> :((x - y) - z)
+    @test AmplNLWriter.convert_formula(expr) == :((x - y) - z)
 end
 
-facts("[nl_convert] check n-ary multiplication") do
+@testset "[nl_convert] check n-ary multiplication" begin
     expr = :(x * y * z)
-    @fact AmplNLWriter.convert_formula(expr) --> :(x * (y * z))
+    @test AmplNLWriter.convert_formula(expr) == :(x * (y * z))
 end
 
-facts("[nl_convert] check comparison expansion") do
+@testset "[nl_convert] check comparison expansion" begin
     expr = :(1 < 2 < 3)
-    @fact AmplNLWriter.convert_formula(expr) --> :(1 < 2 && 2 < 3)
+    @test AmplNLWriter.convert_formula(expr) == :(1 < 2 && 2 < 3)
     expr = :(1 < 2 < 3 < 4)
-    @fact AmplNLWriter.convert_formula(expr) --> :((1 < 2 && 2 < 3) && 3 < 4)
+    @test AmplNLWriter.convert_formula(expr) == :((1 < 2 && 2 < 3) && 3 < 4)
 end

--- a/test/nl_linearity.jl
+++ b/test/nl_linearity.jl
@@ -1,21 +1,21 @@
-facts("[nl_linearity] check simplification of formulae") do
-    context("ifelse") do
+@testset "[nl_linearity] check simplification of formulae" begin
+    @testset "ifelse" begin
         # First term is true, we should choose `then`
         expr = :(ifelse(1 > 0, x[1] ^ 2, x[2] + 1))
         lin_expr = AmplNLWriter.LinearityExpr(expr)
-        @fact AmplNLWriter.convert_formula(lin_expr.c) --> :(x[1] ^ 2)
-        @fact lin_expr.linearity --> :nonlinear
+        @test AmplNLWriter.convert_formula(lin_expr.c) == :(x[1] ^ 2)
+        @test lin_expr.linearity == :nonlinear
 
         # First term is false, we should choose `else`
         expr = :(ifelse(1 < 0, x[1] ^ 2, x[2] + 1))
         lin_expr = AmplNLWriter.LinearityExpr(expr)
-        @fact AmplNLWriter.convert_formula(lin_expr.c) --> :(x[2] + 1)
-        @fact lin_expr.linearity --> :linear
+        @test AmplNLWriter.convert_formula(lin_expr.c) == :(x[2] + 1)
+        @test lin_expr.linearity == :linear
 
         # First term isn't constant, we can't simplify
         expr = :(ifelse(1 > x[1], x[1] ^ 2, x[2] + 1))
         lin_expr = AmplNLWriter.LinearityExpr(expr)
-        @fact AmplNLWriter.convert_formula(lin_expr.c) --> expr
-        @fact lin_expr.linearity --> :nonlinear
+        @test AmplNLWriter.convert_formula(lin_expr.c) == expr
+        @test lin_expr.linearity == :nonlinear
     end
 end

--- a/test/nl_write.jl
+++ b/test/nl_write.jl
@@ -1,4 +1,4 @@
-facts("[nl_write] Temp file handling") do
+@testset "[nl_write] Temp file handling" begin
     # Turn on debug mode so files persist
     old_debug = AmplNLWriter.debug
     AmplNLWriter.setdebug(true)
@@ -9,22 +9,22 @@ facts("[nl_write] Temp file handling") do
     solfile = "$filepath.sol"
     AmplNLWriter.clean_solverdata()
 
-    context("all temp files deleted successfully") do
-        @fact length(readdir(AmplNLWriter.solverdata_dir)) --> 1
+    @testset "all temp files deleted successfully" begin
+        @test length(readdir(AmplNLWriter.solverdata_dir)) == 1
     end
 
-    solver = BonminNLSolver(filename=filename)
+    solver = IpoptNLSolver(filename=filename)#BonminNLSolver(filename=filename)
     m = Model(solver=solver)
     @variable(m, x >= 0)
     @objective(m, Min, x)
     solve(m)
 
-    context("temp files present after solve in debug mode") do
-        @fact length(readdir(AmplNLWriter.solverdata_dir)) --> 3
+    @testset "temp files present after solve in debug mode" begin
+        @test length(readdir(AmplNLWriter.solverdata_dir)) == 3
     end
-    context("temp files used custom name") do
-        @fact isfile(probfile) --> true
-        @fact isfile(solfile) --> true
+    @testset "temp files used custom name" begin
+        @test isfile(probfile) == true
+        @test isfile(solfile) == true
     end
 
     # Reset debug mode and clean up

--- a/test/nl_write.jl
+++ b/test/nl_write.jl
@@ -13,7 +13,7 @@
         @test length(readdir(AmplNLWriter.solverdata_dir)) == 1
     end
 
-    solver = IpoptNLSolver(filename=filename)#BonminNLSolver(filename=filename)
+    solver = AmplNLSolver(Ipopt.amplexe, filename=filename)#BonminNLSolver(filename=filename)
     m = Model(solver=solver)
     @variable(m, x >= 0)
     @objective(m, Min, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using AmplNLWriter, Compat, FactCheck, JuMP
+using AmplNLWriter, Compat, JuMP
 using Base.Test
 
 include("nl_convert.jl")
@@ -8,29 +8,29 @@ include("nl_write.jl")
 solver = JuMP.UnsetSolver()
 solvers = Any[]
 push!(solvers, IpoptNLSolver(["print_level=0"]))
-push!(solvers, BonminNLSolver(["bonmin.nlp_log_level=0";
-                               "bonmin.bb_log_level=0"]))
-push!(solvers, CouenneNLSolver(["bonmin.nlp_log_level=0";
-                                "bonmin.bb_log_level=0"]))
+# push!(solvers, BonminNLSolver(["bonmin.nlp_log_level=0";
+                               # "bonmin.bb_log_level=0"]))
+# push!(solvers, CouenneNLSolver(["bonmin.nlp_log_level=0";
+                                # "bonmin.bb_log_level=0"]))
 # Add tolerance option for couenne
-open("couenne.opt", "w") do f
-  write(f, "allowable_fraction_gap 0.0001")
-end
+# open("couenne.opt", "w")do f
+  # write(f, "allowable_fraction_gap 0.0001")
+# end
 
 examples_path = joinpath(dirname(dirname(@__FILE__)), "examples")
 for solver in solvers
     solvername = getsolvername(solver)
-    facts("[examples] test solver $solvername") do
+    @testset "[examples] test solver $solvername" begin
         for example in ["jump_nltrig.jl", "jump_nlexpr.jl"]
             include(joinpath(examples_path, example))
         end
-        if solvername != "ipopt"
+        # if solvername != "ipopt"
             for example in ["jump_pruning.jl", "jump_minlp.jl",
                             "jump_nonlinearbinary.jl", "jump_no_obj.jl",
                             "jump_const_obj.jl"]
                 include(joinpath(examples_path, example))
             end
-        end
+        # end
         if solvername == "ipopt"
             for example in ["jump_maxmin.jl"]
                 include(joinpath(examples_path, example))
@@ -42,6 +42,4 @@ end
 include(Pkg.dir("JuMP","test","solvers.jl"))
 include(Pkg.dir("JuMP","test","nonlinear.jl"))
 
-rm("couenne.opt")
-
-FactCheck.exitstatus()
+# rm("couenne.opt")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,45 +1,27 @@
-using AmplNLWriter, Compat, JuMP
+using AmplNLWriter, JuMP, Ipopt
 using Base.Test
 
 include("nl_convert.jl")
 include("nl_linearity.jl")
 include("nl_write.jl")
 
-solver = JuMP.UnsetSolver()
 solvers = Any[]
-push!(solvers, IpoptNLSolver(["print_level=0"]))
-# push!(solvers, BonminNLSolver(["bonmin.nlp_log_level=0";
-                               # "bonmin.bb_log_level=0"]))
-# push!(solvers, CouenneNLSolver(["bonmin.nlp_log_level=0";
-                                # "bonmin.bb_log_level=0"]))
-# Add tolerance option for couenne
-# open("couenne.opt", "w")do f
-  # write(f, "allowable_fraction_gap 0.0001")
-# end
+push!(solvers, AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
 
 examples_path = joinpath(dirname(dirname(@__FILE__)), "examples")
+
 for solver in solvers
     solvername = getsolvername(solver)
     @testset "[examples] test solver $solvername" begin
-        for example in ["jump_nltrig.jl", "jump_nlexpr.jl"]
+        for example in [
+                "jump_nltrig.jl", "jump_nlexpr.jl", "jump_pruning.jl",
+                "jump_minlp.jl", "jump_nonlinearbinary.jl", "jump_no_obj.jl",
+                "jump_const_obj.jl", "jump_maxmin.jl"
+            ]
             include(joinpath(examples_path, example))
-        end
-        # if solvername != "ipopt"
-            for example in ["jump_pruning.jl", "jump_minlp.jl",
-                            "jump_nonlinearbinary.jl", "jump_no_obj.jl",
-                            "jump_const_obj.jl"]
-                include(joinpath(examples_path, example))
-            end
-        # end
-        if solvername == "ipopt"
-            for example in ["jump_maxmin.jl"]
-                include(joinpath(examples_path, example))
-            end
         end
     end
 end
 
 include(Pkg.dir("JuMP","test","solvers.jl"))
 include(Pkg.dir("JuMP","test","nonlinear.jl"))
-
-# rm("couenne.opt")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,10 @@ include("nl_convert.jl")
 include("nl_linearity.jl")
 include("nl_write.jl")
 
+# needed for the scoping of `solver` in the examples
+solver = JuMP.UnsetSolver()
 solvers = Any[]
-push!(solvers, AmplNLSolver(Ipopt.amplexe, ["print_level=0"])
+push!(solvers, AmplNLSolver(Ipopt.amplexe, ["print_level=0"]))
 
 examples_path = joinpath(dirname(dirname(@__FILE__)), "examples")
 


### PR DESCRIPTION
*This PR should probably be split into some smaller ones*

### Allowing .sol files to be read from an IO stream

I'm playing around with the NL file-format interface to NEOS (ref https://neos-server.org/neos/solvers/milp:CPLEX/NL.html and https://github.com/odow/NEOS.jl/issues/17).

I made some changes so I can read the .sol file from a stream instead of having to write the file to disk.

### Changed tests to `@testset`

I've also removed CoinOptServices from the testing suite as it needs some work and was causing failures on my windows machine.

### Dumping the XXXNLSolver
I've removed `BonminNLSolver`, `CouenneNLSolver`, and `IpoptNLSolver` (and therefore the conditional dependencies) in favour of forcing the user to explicitly construct the solvers.

```julia
using AmplNLWriter
solver = IpoptNLSolver()
```
becomes
```julia
using AmplNLWriter, Ipopt
solver = AmplNLSolver(Ipopt.amplexe)
```
which is a bit more clear and less magical about what is actually occuring. 

**This is a hard breaking change for current users.**

Hopefully this fixes #65 

Todo before merge
 - [x] update README
 - [x] update JuMP solver table

### Removed support for v0.5
<s>This uses Julia v0.6 syntax (`.!`) but doesn't change the REQUIRE yet so still todo:
 - [ ] fix deprecation properly by bumping version or using compat</s>

Closes #64 

### Better error message

If a solver crashes without producing a `.sol` file the user gets a slightly more helpful error message. Closes #67 

### Added codecov

Closes #69 