### PR TITLE
Fix bug in sol file parser if the file begins with empty lines.

### DIFF
--- a/examples/jump_minlp.jl
+++ b/examples/jump_minlp.jl
@@ -43,7 +43,7 @@ using JuMP, Base.Test, AmplNLWriter
 
     @test solve(m) == :Optimal
 
-    if getsolvername(solver) == "ipopt"
+    if contains(getsolvername(solver), "ipopt")
         # Ipopt solves the relaxation
         @test isapprox(getvalue(x)[:], [1.14652, 0.546596, 1.0], atol=1e-5)
         @test isapprox(getvalue(y)[:], [0.27330, 0.299959, 0.0], atol=1e-5)

--- a/examples/jump_nonlinearbinary.jl
+++ b/examples/jump_nonlinearbinary.jl
@@ -23,7 +23,7 @@ using JuMP, Base.Test, AmplNLWriter
 
     @test solve(m) == :Optimal
 
-    if getsolvername(solver) == "ipopt"
+    if contains(getsolvername(solver), "ipopt")
         # Ipopt solves the relaxation
         @test isapprox(getvalue(x), [0.501245, 1.0], atol=1e-6)
         @test isapprox(getobjectivevalue(m), 0.249377, atol=1e-6)

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -653,7 +653,7 @@ function read_sol(f::IO, m::AmplNLMathProgModel)
     # "Options".
     while true
         line = readline(f)
-        if line[1:7] == "Options"
+        if length(line) >= 7 && line[1:7] == "Options"
             break
         else
             m.solve_message *= line

--- a/src/AmplNLWriter.jl
+++ b/src/AmplNLWriter.jl
@@ -394,7 +394,7 @@ function optimize!(m::AmplNLMathProgModel)
     end
     m.probfile = "$file_basepath.nl"
     m.solfile = "$file_basepath.sol"
-    
+
     try
         write_nl_file(f_prob, m)
     finally
@@ -649,17 +649,15 @@ function read_sol(f::IO, m::AmplNLMathProgModel)
     stat = :Undefined
     line = ""
 
-    # Keep building solver message by reading until first truly empty line
+    # Extract the solver message by concatenating all of the lines until
+    # "Options".
     while true
         line = readline(f)
-        isempty(chomp(line)) && break
-        m.solve_message *= line
-    end
-
-    # Skip over empty lines
-    while true
-        line = readline(f)
-        !isempty(chomp(line)) && break
+        if line[1:7] == "Options"
+            break
+        else
+            m.solve_message *= line
+        end
     end
 
     # Read through all the options. Direct copy of reference implementation.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Base.Test
 include("nl_convert.jl")
 include("nl_linearity.jl")
 include("nl_write.jl")
+include("sol_file_parser.jl")
 
 # needed for the scoping of `solver` in the examples
 solver = JuMP.UnsetSolver()

--- a/test/sol_file_parser.jl
+++ b/test/sol_file_parser.jl
@@ -1,0 +1,29 @@
+const FILE_80 = """
+
+ Couenne (/home/bgulcan/.julia/v0.6/AmplNLWriter/.solverdata/tmpMSxFvq.nl Mar  6 2018): Infeasible
+
+Options
+3
+0
+1
+0
+140
+0
+110
+0
+objno 0 220
+"""
+
+@testset "Test sol file parsing" begin
+    @testset "Issue #80" begin
+        io = IOBuffer()
+        write(io, FILE_80)
+        seekstart(io)
+        model = AmplNLWriter.AmplNLMathProgModel("", String[], "")
+        model.ncon = 140
+        model.nvar = 110
+        @test !AmplNLWriter.read_sol(io, model)
+        @test model.solve_result_num == 220
+        @test all(model.solution .=== NaN)
+    end
+end


### PR DESCRIPTION
As found by @bgulcan, here is an offending `.sol` file returned by Couenne that `AmplNLWriter.jl` cannot parse. The problem is that it starts with an empty line. To simplify things, this PR just returns all lines prior to `Options` concatenated together as the solver message. Since this is solver-specific and intended for the user, this doesn't seem like a bad thing to do.
```

 Couenne (/home/bgulcan/.julia/v0.6/AmplNLWriter/.solverdata/tmpMSxFvq.nl Mar  6 2018): Infeasible

Options
3
0
1
0
140
0
110
0
objno 0 220
```
Closes #80 

- [x] needs tests