### PR TITLE
Fixed MOI.Utilities model call by substituting (MOI.SingleVariable,),…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 Ipopt = "≥ 0.1.15"
 JuMP = "~0.19.0"
-MathOptInterface = "~0.8.2"
+MathOptInterface = "≥ 0.9"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 Ipopt = "≥ 0.1.15"
 JuMP = "~0.19.0"
-MathOptInterface = "≥ 0.9"
+MathOptInterface = "0.9"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
 julia = "1"
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -10,7 +10,7 @@ MOIU.@model(InnerModel,
     (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval),
     (),
     (),
-    (MOI.SingleVariable,),
+    (),
     (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
     (),
     ()


### PR DESCRIPTION
Fixed issue caused by MOI.SingleVariable use in JuMP 0.2.0/MOI 0.9 by replacing (MOI.SingleVariable,), by (), as per @blegat recommendation.