### PR TITLE
Add better error handling and msg for run cmd errors

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -30,6 +30,7 @@ const MOI_SCALAR_FUNCTIONS = (
 "Struct to contain the MPB solution."
 struct MPBSolution
     status::Symbol
+    raw_status_string::String
     objective_value::Float64
     primal_solution::Dict{MOI.VariableIndex, Float64}
 end
@@ -394,6 +395,7 @@ function MOI.optimize!(model::Model)
     end
     model.ext[:MPBSolutionAttribute] = MPBSolution(
         MPB.status(mpb_model),
+        mpb_model.inner.solve_result,
         MPB.getobjval(mpb_model),
         primal_solution
     )
@@ -470,4 +472,9 @@ function MOI.get(model::Model, ::MOI.ResultCount)
     else
         return 0
     end
+end
+
+function MOI.get(model::Model, ::MOI.RawStatusString)
+    mpb_solution = mpb_solution_attribute(model)
+    return mpb_solution.raw_status_string
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -96,3 +96,11 @@ end
     # Requires ExprGraph in MOI tests
     # MOIT.nlptest(OPTIMIZER, CONFIG)
 end
+
+@testset "RawStatusString" begin
+    model = AmplNLWriter.Optimizer("bad_solver")
+    x = MOI.add_variable(model)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OTHER_ERROR
+    @test occursin("IOError", MOI.get(model, MOI.RawStatusString()))
+end


### PR DESCRIPTION
A common issue seems to be the solver erroring at some point. Let's try-catch, throw a nicer error message, and make it available via `RawStatusString`.

Closes #92 
Closes #78